### PR TITLE
Fix for OutputerStreamFlux

### DIFF
--- a/Source/moja.flint/include/moja/flint/outputerstreamflux.h
+++ b/Source/moja.flint/include/moja/flint/outputerstreamflux.h
@@ -28,6 +28,7 @@ class FLINT_API OutputerStreamFlux : public ModuleBase {
    void onSystemShutdown() override;
    void onTimingPostInit() override;
    void onTimingEndStep() override;
+   void onPostDisturbanceEvent() override; 
 
   protected:
    std::string _fileName;

--- a/Source/moja.flint/src/outputerstreamflux.cpp
+++ b/Source/moja.flint/src/outputerstreamflux.cpp
@@ -37,6 +37,7 @@ void OutputerStreamFlux::subscribe(NotificationCenter& notificationCenter) {
    notificationCenter.subscribe(signals::SystemShutdown, &OutputerStreamFlux::onSystemShutdown, *this);
    notificationCenter.subscribe(signals::TimingPostInit, &OutputerStreamFlux::onTimingPostInit, *this);
    notificationCenter.subscribe(signals::TimingEndStep, &OutputerStreamFlux::onTimingEndStep, *this);
+   notificationCenter.subscribe(signals::PostDisturbanceEvent, &OutputerStreamFlux::onPostDisturbanceEvent, *this);
 }
 
 // --------------------------------------------------------------------------------------------
@@ -140,6 +141,10 @@ void OutputerStreamFlux::onTimingPostInit() { outputInit(_output); }
 // --------------------------------------------------------------------------------------------
 
 void OutputerStreamFlux::onTimingEndStep() { outputEndStep(_output); }
+
+// --------------------------------------------------------------------------------------------
+
+void OutputerStreamFlux::onPostDisturbanceEvent() { outputEndStep(_output); }
 
 }  // namespace flint
 }  // namespace moja


### PR DESCRIPTION
Fix for an issue with OutputerStreamFlux
+ was missing a handler for on onPostDisturbanceEvent
+ means disturbance events were not being recorded
+ the system was processing the flux, just not captured by this module