### PR TITLE
Updated commands in README.md to match with developer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A fork of a *Vcpkg* repository has been created for the FLINT required libraries
   bootstrap-vcpkg.bat
   
   # install packages
-  vcpkg.exe install boost-test:x64-windows boost-program-options:x64-windows boost-log:x64-windows turtle:x64-windows zipper:x64-windows poco:x64-windows libpq:x64-windows gdal:x64-windows sqlite3:x64-windows boost-ublas:x64-windows
+  vcpkg.exe install boost-test:x64-windows boost-program-options:x64-windows boost-log:x64-windows turtle:x64-windows zipper:x64-windows poco:x64-windows libpq:x64-windows gdal:x64-windows sqlite3:x64-windows boost-ublas:x64-windows fmt:x64-windows libpqxx:x64-windows
   ```
 
 + Once this has completed, start a command shell in your FLINT repository folder. Now use the following commands to create the Visual Studio solution:


### PR DESCRIPTION
Signed-off-by: waridrox <mohdwarid4@gmail.com>

The commands to install vcpkg packages were recently updated in the official developer documentation to run FLINT.Example and GCBM build. They should also be updated in the README.md file to address the issue #80.