### PR TITLE
Updates in the spatialtiledlocaldomaincontroller.cpp

### DIFF
--- a/Source/moja.flint/src/spatialtiledlocaldomaincontroller.cpp
+++ b/Source/moja.flint/src/spatialtiledlocaldomaincontroller.cpp
@@ -792,25 +792,27 @@ bool SpatialTiledLocalDomainController::runCellSpinUp(std::shared_ptr<StatsUnitR
          blockStatsUnit->_unitsProcessed++;
          return true;
       } catch (const flint::SimulationError& e) {
-         std::string details = *(boost::get_error_info<Details>(e));
-         std::string libraryName = *(boost::get_error_info<LibraryName>(e));
-         std::string moduleName = *(boost::get_error_info<ModuleName>(e));
-         const int* errorCode = boost::get_error_info<ErrorCode>(e);
-         _spatiallocationinfo->_errorCode = *errorCode;
-         _spatiallocationinfo->_library = libraryName;
-         _spatiallocationinfo->_module = moduleName;
-         _spatiallocationinfo->_message = details;
+         //std::string details = *(boost::get_error_info<Details>(e));
+         //std::string libraryName = *(boost::get_error_info<LibraryName>(e));
+         //std::string moduleName = *(boost::get_error_info<ModuleName>(e));
+         //const int* errorCode = boost::get_error_info<ErrorCode>(e);
+         //_spatiallocationinfo->_errorCode = *errorCode;
+         //_spatiallocationinfo->_library = libraryName;
+         //_spatiallocationinfo->_module = moduleName;
+         //_spatiallocationinfo->_message = details;
+         std::string details = _handleFLINTException(e); //Template function call
          _spinupNotificationCenter.postNotification(moja::signals::Error, details);
          return true;
       } catch (const flint::LocalDomainError& e) {
-         std::string details = *(boost::get_error_info<Details>(e));
-         std::string libraryName = *(boost::get_error_info<LibraryName>(e));
-         std::string moduleName = *(boost::get_error_info<ModuleName>(e));
-         const int* errorCode = boost::get_error_info<ErrorCode>(e);
-         _spatiallocationinfo->_errorCode = *errorCode;
-         _spatiallocationinfo->_library = libraryName;
-         _spatiallocationinfo->_module = moduleName;
-         _spatiallocationinfo->_message = details;
+         //std::string details = *(boost::get_error_info<Details>(e));
+         //std::string libraryName = *(boost::get_error_info<LibraryName>(e));
+         //std::string moduleName = *(boost::get_error_info<ModuleName>(e));
+         //const int* errorCode = boost::get_error_info<ErrorCode>(e);
+         //_spatiallocationinfo->_errorCode = *errorCode;
+         //_spatiallocationinfo->_library = libraryName;
+         //_spatiallocationinfo->_module = moduleName;
+         //_spatiallocationinfo->_message = details;
+         std::string details = _handleFLINTException(e); //Template function call
          _spinupNotificationCenter.postNotification(moja::signals::Error, details);
       } catch (flint::VariableNotFoundException& e) {
          std::string str =
@@ -843,6 +845,20 @@ bool SpatialTiledLocalDomainController::runCellSpinUp(std::shared_ptr<StatsUnitR
       return false;
    }
    return true;
+}
+// Here this template function will handle all the string and spatiallocationinfo for
+//both the LocalDomainError and SimulationError. From lines 794-816.
+template <typename FlintExceptionType&>
+std::string _handleFLINTException(const FlintExceptionType& e) {
+   std::string details = *(boost::get_error_info<Details>(e));
+   std::string libraryName = *(boost::get_error_info<LibraryName>(e));
+   std::string moduleName = *(boost::get_error_info<ModuleName>(e));
+   const int* errorCode = boost::get_error_info<ErrorCode>(e);
+   _spatiallocationinfo->_errorCode = *errorCode;
+   _spatiallocationinfo->_library = libraryName;
+   _spatiallocationinfo->_module = moduleName;
+   _spatiallocationinfo->_message = details;
+   return details;
 }
 
 // --------------------------------------------------------------------------------------------


### PR DESCRIPTION
This change is for the issue #48 
The catch blocks for SimulationError and LocalDomainError had messy and repetitive codes which are now defined in one function _handleFLINTException.
Signed-off-by: Debolina Ghatuary <debolinaghatuary200011@gmail.com>