### PR TITLE
BLD: Fix the base FLINT Docker build

### DIFF
--- a/Examples/docker/Dockerfile.base.ubuntu.18.04
+++ b/Examples/docker/Dockerfile.base.ubuntu.18.04
@@ -50,7 +50,7 @@ RUN apt-get update -y && apt-get install -y \
 # set versions of libraries used and some paths
 ENV ROOTDIR /usr/local/
 ENV GDAL_VERSION 2.4.0
-ENV CMAKE_VERSION 3.14.3
+ENV CMAKE_VERSION 3.15.0
 ENV POCO_VERSION 1.9.0
 ENV BOOST_VERSION 1_69_0
 ENV BOOST_VERSION_DOT 1.69.0
@@ -90,7 +90,7 @@ RUN cd src && tar -xzf poco-${POCO_VERSION}.tar.gz && cd poco-${POCO_VERSION} \
     && cd $ROOTDIR
 
 ## Boost
-ADD https://dl.bintray.com/boostorg/release/${BOOST_VERSION_DOT}/source/boost_${BOOST_VERSION}.tar.bz2 $ROOTDIR/src/
+ADD https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION_DOT}/source/boost_${BOOST_VERSION}.tar.bz2 $ROOTDIR/src/
 RUN cd src && tar --bzip2 -xf boost_${BOOST_VERSION}.tar.bz2 && cd boost_${BOOST_VERSION}  \
     && ./bootstrap.sh --prefix=/usr/local \
     && ./b2 -j $NUM_CPU cxxstd=14 install \


### PR DESCRIPTION
## Description

Fixes #112 

This PR:

- Bumps the CMake version to 3.15.0
- Migrate Boost release link from Bintray to JFrog