### PR TITLE
Update links and version 

### DIFF
--- a/Examples/docker/Dockerfile.base.ubuntu.18.04
+++ b/Examples/docker/Dockerfile.base.ubuntu.18.04
@@ -50,12 +50,12 @@ RUN apt-get update -y && apt-get install -y \
 # set versions of libraries used and some paths
 ENV ROOTDIR /usr/local/
 ENV GDAL_VERSION 2.4.0
-ENV CMAKE_VERSION 3.14.3
+ENV CMAKE_VERSION 3.15.0
 ENV POCO_VERSION 1.9.0
 ENV BOOST_VERSION 1_69_0
 ENV BOOST_VERSION_DOT 1.69.0
 ENV FMT_VERSION 5.3.0
-ENV SQLITE_VERSION 3270200
+ENV SQLITE_VERSION 3370200
 
 # set environment variables
 ENV PATH /usr/local/bin:$PATH
@@ -90,7 +90,8 @@ RUN cd src && tar -xzf poco-${POCO_VERSION}.tar.gz && cd poco-${POCO_VERSION} \
     && cd $ROOTDIR
 
 ## Boost
-ADD https://dl.bintray.com/boostorg/release/${BOOST_VERSION_DOT}/source/boost_${BOOST_VERSION}.tar.bz2 $ROOTDIR/src/
+ADD https://liquidtelecom.dl.sourceforge.net/project/boost/boost/\ 
+${BOOST_VERSION_DOT}/boost_${BOOST_VERSION}.tar.bz2 $ROOTDIR/src/
 RUN cd src && tar --bzip2 -xf boost_${BOOST_VERSION}.tar.bz2 && cd boost_${BOOST_VERSION}  \
     && ./bootstrap.sh --prefix=/usr/local \
     && ./b2 -j $NUM_CPU cxxstd=14 install \
@@ -110,9 +111,9 @@ RUN cd src &&  mkdir libfmt-${FMT_VERSION} && tar -xzf ${FMT_VERSION}.tar.gz -C 
 #RUN cd src && tar -xzf sqlite-autoconf-${SQLITE_VERSION}.tar.gz -C /usr/include/ \
 #    && cd $ROOTDIR && rm -Rf src/sqlite*
 
-ADD https://www.sqlite.org/2019/sqlite-autoconf-${SQLITE_VERSION}.tar.gz $ROOTDIR/src/
-RUN cd src && tar -xzf sqlite-autoconf-${SQLITE_VERSION}.tar.gz -C /usr/local/ \
-	&& cp /usr/local/sqlite-autoconf-${SQLITE_VERSION}/sqlite3.c /usr/include/ \
+ADD https://www.sqlite.org/2022/\sqlite-autoconf-${SQLITE_VERSION}.tar.gz $ROOTDIR/src/
+RUN cd src && tar -xzf sqlite-autoconf-${SQLITE_VERSION}.tar.gz -C /usr/local \
+	&& cp /usr/local/sqlite-autoconf-${SQLITE_VERSION}/sqlite3.c /usr/include \
     && cd $ROOTDIR && rm -Rf src/sqlite*
 
 ## gdal
@@ -147,4 +148,3 @@ RUN wget https://sourceforge.net/projects/turtle/files/turtle/1.3.1/turtle-1.3.1
 
 #ADD http://downloads.sourceforge.net/project/turtle/turtle/1.3.1/turtle-1.3.1.tar.bz2 $ROOTDIR/src/
 #RUN tar xvf turtle-1.3.0.tar.bz2 -C /usr/local/
-WORKDIR $ROOTDIR/src


### PR DESCRIPTION
## Description 

- Updated the BOOST link from Bintray to Sourceforge. 
- Updated the SQLite version and link from 2019 to 2022.
- Removed the WORKDIR at the end of the docker file, since the FLINT library image has already mentioned the WORKDIR in the docker file. 

The changed code runs successfully. 

Please review it, @Tonnix @aornugent @HarshCasper. Thanks.