### PR TITLE
Centralize Docker images: fixed broken links and missing libraries

### DIFF
--- a/Source/docker/Dockerfile.base.ubuntu.18.04
+++ b/Source/docker/Dockerfile.base.ubuntu.18.04
@@ -50,7 +50,7 @@ RUN apt-get update -y && apt-get install -y \
 # set versions of libraries used and some paths
 ENV ROOTDIR /usr/local/
 ENV GDAL_VERSION 2.4.0
-ENV CMAKE_VERSION 3.14.3
+ENV CMAKE_VERSION 3.15.0
 ENV POCO_VERSION 1.9.0
 ENV BOOST_VERSION 1_69_0
 ENV BOOST_VERSION_DOT 1.69.0
@@ -90,12 +90,13 @@ RUN cd src && tar -xzf poco-${POCO_VERSION}.tar.gz && cd poco-${POCO_VERSION} \
     && cd $ROOTDIR
 
 ## Boost
-ADD https://dl.bintray.com/boostorg/release/${BOOST_VERSION_DOT}/source/boost_${BOOST_VERSION}.tar.bz2 $ROOTDIR/src/
-RUN cd src && tar --bzip2 -xf boost_${BOOST_VERSION}.tar.bz2 && cd boost_${BOOST_VERSION}  \
-    && ./bootstrap.sh --prefix=/usr/local \
-    && ./b2 -j $NUM_CPU cxxstd=14 install \
+RUN wget -c https://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION_DOT}/boost_${BOOST_VERSION}.tar.bz2/download -O boost_${BOOST_VERSION}.tar.bz2 \
+    && tar --bzip2 -xf boost_${BOOST_VERSION}.tar.bz2 \
+	&& cd boost_${BOOST_VERSION}  \
+    && ./bootstrap.sh --prefix=$ROOTDIR \
+    && ./b2 -d0 -j $NUM_CPU cxxstd=14 install variant=release link=shared  \
     && ./b2 clean \
-    && cd $ROOTDIR
+    && cd $ROOTDIR/src
 
 ## FMT
 ADD https://github.com/fmtlib/fmt/archive/${FMT_VERSION}.tar.gz $ROOTDIR/src/         

--- a/Source/docker/Dockerfile.flint.ubuntu.18.04
+++ b/Source/docker/Dockerfile.flint.ubuntu.18.04
@@ -15,8 +15,8 @@ ARG GITHUB_AT
 ARG FLINT_BRANCH
 ARG NUM_CPU=1
 ARG DEBIAN_FRONTEND=noninteractive
-
-ENV SQLITE_VERSION 3270200
+ENV POCO_VERSION 1.9.2
+ENV SQLITE_VERSION 3370200
 ENV ROOTDIR /usr/local/
 
 WORKDIR $ROOTDIR/
@@ -29,11 +29,48 @@ ENV CURL_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt
 ENV GDAL_DATA=/usr/share/gdal
 ENV GDAL_HTTP_VERSION 2
 
-ADD https://www.sqlite.org/2019/sqlite-autoconf-${SQLITE_VERSION}.tar.gz $ROOTDIR/src/
+RUN apt-get install -y postgresql-client-10 \
+    postgresql-server-dev-10 \
+    && apt-get -y autoremove \
+    && 	apt-get clean 
+
+ADD https://www.sqlite.org/2022/sqlite-autoconf-${SQLITE_VERSION}.tar.gz $ROOTDIR/src/
 RUN cd src && tar -xzf sqlite-autoconf-${SQLITE_VERSION}.tar.gz -C /usr/local/ \
 	&& cp /usr/local/sqlite-autoconf-${SQLITE_VERSION}/sqlite3.c /usr/include/ \
     && cd $ROOTDIR && rm -Rf src/sqlite*
 
+RUN wget https://pocoproject.org/releases/poco-${POCO_VERSION}/poco-${POCO_VERSION}-all.tar.gz \
+    && tar -xzf poco-${POCO_VERSION}-all.tar.gz \
+	&& mkdir poco-${POCO_VERSION}-all/cmake-build \
+	&& cd poco-${POCO_VERSION}-all/cmake-build \
+	&& cmake -DCMAKE_BUILD_TYPE=RELEASE \
+			 -DCMAKE_INSTALL_PREFIX=$ROOTDIR \
+			 -DPOCO_UNBUNDLED=ON \
+			 -DPOCO_STATIC=OFF \
+			 -DENABLE_ENCODINGS=OFF \
+			 -DENABLE_ENCODINGS_COMPILER=OFF \
+			 -DENABLE_XML=OFF \
+			 -DENABLE_JSON=ON \
+			 -DENABLE_MONGODB=OFF \
+			 -DENABLE_REDIS=OFF \
+			 -DENABLE_PDF=OFF \
+			 -DENABLE_UTIL=OFF \
+			 -DENABLE_NET=OFF \
+			 -DENABLE_NETSSL=OFF \
+			 -DENABLE_CRYPTO=OFF \
+			 -DENABLE_DATA=ON \
+			 -DENABLE_DATA_SQLITE=ON \
+			 -DENABLE_DATA_MYSQL=OFF \
+			 -DENABLE_DATA_ODBC=OFF \
+			 -DENABLE_SEVENZIP=OFF \
+			 -DENABLE_ZIP=OFF \
+			 -DENABLE_PAGECOMPILER=OFF \
+			 -DENABLE_PAGECOMPILER_FILE2PAGE=OFF \
+			 -DENABLE_TESTS:BOOL=OFF .. \
+	&& make --quiet -j $NUM_CPU \
+    && make --quiet install/strip \
+    && make clean \
+    && cd $ROOTDIR/src
 
 # GET FLINT
 WORKDIR $ROOTDIR/

--- a/Source/moja.core/CMakeLists.txt
+++ b/Source/moja.core/CMakeLists.txt
@@ -3,8 +3,8 @@ set(LIBNAME "moja.${PACKAGE}")
 string(TOUPPER "${PACKAGE}" LIBNAME_EXPORT)
 
 include(${CMAKE_MODULE_PATH}/generate_product_version.cmake) 
+include(${CMAKE_SOURCE_DIR}/cmake/Modules/PocoConfig.cmake)
 
-find_package(Poco REQUIRED Foundation JSON)
 find_package(Boost COMPONENTS log log_setup REQUIRED)
 
 if (MSVC)


### PR DESCRIPTION
Fixed broken links and compatibility issues.
To run tests, use the following commands:
- [x] For baseimage:
~# docker build -f Dockerfile.base.ubuntu.18.04 --build-arg NUM_CPU=4 -t moja/baseimage:ubuntu-18.04 .
- [x] For flint implementation:
~# docker build  -f Dockerfile.flint.ubuntu.18.04 --build-arg NUM_CPU=4 --build-arg GITHUB_AT=[TOKEN] --build-arg FLINT_BRANCH=[BRANCH] -t moja/flint:ubuntu-18.04 .