### PR TITLE
Fix C, Mutex imports in Poco 1.11.1

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10.0)
-project(moja VERSION 1.0.6 LANGUAGES CXX)
+project(moja VERSION 1.1.0 LANGUAGES CXX C)
 
 #turn on using solution folders
 set_property( GLOBAL PROPERTY USE_FOLDERS ON)
@@ -55,7 +55,7 @@ option(MOJA_STATIC				"Set to OFF|ON (default is OFF) to control build of moja a
 
 # Uncomment from next two lines to force statitc or dynamic library, default is autodetection
 if(MOJA_STATIC)
-    add_definitions( -DMOJA_STATIC -DMOJA_NO_AUTOMATIC_LIBS)    
+    add_definitions( -DMOJA_STATIC -DMOJA_NO_AUTOMATIC_LIBS)
     set( LIB_MODE STATIC )
     message(STATUS "Building static libraries")
 else(MOJA_STATIC)
@@ -273,7 +273,7 @@ install(FILES ${MOJA_PKG_CONFIG_FILES}
         DESTINATION lib${LIB_SUFFIX}/pkgconfig)
 
 export(PACKAGE Moja)
-		
+
 message(STATUS "CMake ${CMAKE_VERSION} successfully configured ${PROJECT_NAME} using ${CMAKE_GENERATOR} generator")
 message(STATUS "Installation target path: ${CMAKE_INSTALL_PREFIX}")
 

--- a/Source/moja.flint/include/moja/flint/writesystemconfig.h
+++ b/Source/moja.flint/include/moja/flint/writesystemconfig.h
@@ -3,6 +3,8 @@
 
 #include <moja/flint/modulebase.h>
 
+#include <Poco/Mutex.h>
+
 #include <boost/iostreams/stream_buffer.hpp>
 
 namespace moja {

--- a/Source/moja.flint/include/moja/flint/writevariablegrid.h
+++ b/Source/moja.flint/include/moja/flint/writevariablegrid.h
@@ -7,6 +7,8 @@
 #include "moja/flint/ipool.h"
 #include "moja/flint/modulebase.h"
 
+#include <Poco/Mutex.h>
+
 #include <boost/algorithm/string.hpp>
 
 #include <algorithm>

--- a/Source/moja.modules.gdal/include/moja/modules/gdal/writevariablegeotiff.h
+++ b/Source/moja.modules.gdal/include/moja/modules/gdal/writevariablegeotiff.h
@@ -8,6 +8,10 @@
 #include <moja/flint/ipool.h>
 #include <moja/flint/modulebase.h>
 
+#include <Poco/File.h>
+#include <Poco/Mutex.h>
+#include <Poco/Path.h>
+
 #include <unordered_map>
 
 namespace moja {

--- a/Source/moja.modules.gdal/src/writevariablegeotiff.cpp
+++ b/Source/moja.modules.gdal/src/writevariablegeotiff.cpp
@@ -12,9 +12,7 @@
 #include <moja/notificationcenter.h>
 #include <moja/signals.h>
 
-#include <Poco/File.h>
 #include <Poco/Mutex.h>
-#include <Poco/Path.h>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>


### PR DESCRIPTION
In [this Dockerfile](https://github.com/moja-global/FLINT.Cloud/blob/gcbm-container/rest_api_gcbm/Dockerfile) I updated the FLINT dependencies from those given in the `FLINT` Dockerfiles:

[FLINT base Dockerfile](https://github.com/moja-global/FLINT/blob/develop/Docker/Dockerfile.base.ubuntu.18.04)
| Dependency | old version | new version |
| ----- | ----- | ----- |
| Ubuntu | 18.04 (bionic) | 20.04 (focal) |
| Poco | 1.9.2 | 1.11.1 |
| GDAL | 2.4.1 | 3.4.1 |
| Boost | 1.72.0 | 1.78.0 |
| fmt | 6.1.2 | 8.1.1 |

Moving to Poco 1.9.2 this presented three minor bugs during FLINT compilation:
* The Poco Mutex headers were not being found for some reason, explicitly importing them in the `writesystemconfig` and `writevariablegrid` headers helped.
* I'm not quite sure why but we appear to have a C dependency that now needs to be explicit to Poco. [This issue is being on the Poco project](https://github.com/pocoproject/poco/issues/3308). Adding C as an enabled language in `moja.modules.cbm/CMakeLists.txt` resolved this.

@malfrancis  - I'm in no great rush, but I'd love to know whether these minor changes are backwards compatible. Please let me know if you have time to trial this build.
