### PR TITLE
Updated boost url for base docker container

### DIFF
--- a/Docker/Dockerfile.base.ubuntu.18.04
+++ b/Docker/Dockerfile.base.ubuntu.18.04
@@ -100,7 +100,7 @@ RUN wget https://pocoproject.org/releases/poco-${POCO_VERSION}/poco-${POCO_VERSI
 # build user-config.jam files
 RUN echo "using python : 3.6 : /usr ;" > ~/user-config.jam
 
-RUN wget https://dl.bintray.com/boostorg/release/${BOOST_VERSION_DOT}/source/boost_${BOOST_VERSION}.tar.bz2 \
+RUN wget https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION_DOT}/source/boost_${BOOST_VERSION}.tar.bz2 \
     && tar --bzip2 -xf boost_${BOOST_VERSION}.tar.bz2 && cd boost_${BOOST_VERSION}  \
     && ./bootstrap.sh --prefix=$ROOTDIR \
     && ./b2 -d0 -j $NUM_CPU cxxstd=14 install variant=release link=shared  \


### PR DESCRIPTION
# Pull Request Template

## Description
Current Docker image was using Bintray for downloading boost files which has been already retired. I have changed it to Jfrog that is currently being used by boost. It was resulting in broken builds due to 404.

Fixes # (issue)
#112 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I have used the updated Dockerfile to successfully build the base image.
I used 
```docker build -f Dockerfile.base.ubuntu.18.04 --build-arg NUM_CPU=4 -t moja/baseimage:ubuntu-18.04 .```

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
